### PR TITLE
Treat dates that contain only zero and/or space as null. (example: b'00000000  ')

### DIFF
--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -54,8 +54,8 @@ class FieldParser:
             
             return datetime.date(year, month, day)
         except ValueError:
-            if data.strip(b' ') == b'' or data.strip(b'0') == b'':
-                # All spaces or all zeroes are NULL values.
+            if data.strip(b' ').strip(b'0') == b'':
+                # A record containing only spaces and/or zeros is a NULL value.
                 return None
             else:
                 raise ValueError('invalid date {!r}'.format(data))


### PR DESCRIPTION
Found a files has both zeros and spaces in the date field, which should also be NULL/None.
