### PR TITLE
Added support for currency field parsing

### DIFF
--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -200,6 +200,16 @@ class FieldParser:
                 return None
         else:
             return None
+            
+    def parseY(self, field, data):
+        """Parse currency field (Y) and return float."""
+        int_val = int.from_bytes(data, byteorder='little')
+        # Can also retrieve int value with struct.unpack('q', data)[0]
+        
+        # Currency fields are stored with 4 points of precision
+        float_val = int_val / 10000
+        return float_val
+
 
     def parseB(self, field, data):
         """Binary memo field or double precision floating point number


### PR DESCRIPTION
Initial use of library threw error when encountering a currency field.  Documentation suggested adding custom field types by subclassing FieldParser.  However currency isn't really a custom field, it's been a supported field for a while (http://msdn.microsoft.com/en-us/library/aa975386(v=vs.71).aspx)  Therefore it would probably be a better solution to add it to the core FieldParser class.
