### PR TITLE
Use get_memo instead of _get_memo in FieldParser

### DIFF
--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -229,13 +229,13 @@ class FieldParser:
         """OLE Object stored in memofile.
 
         The raw data is returned as a binary string."""
-        return self._get_memo(self._parse_memo_index(data))
+        return self.get_memo(self._parse_memo_index(data))
 
     def parseP(self, field, data):
         """Picture stored in memofile.
 
         The raw data is returned as a binary string."""
-        return self._get_memo(self._parse_memo_index(data))
+        return self.get_memo(self._parse_memo_index(data))
 
 
     # Autoincrement field ('+')


### PR DESCRIPTION
I encountered a foxpro file that declared a some pictures as 'M'. 
So I subclassed FieldParser, delegated parseM to parseG, and found this bug.