### PR TITLE
Converting records to a pandas.DataFrame

### DIFF
--- a/dbfread/dbf.py
+++ b/dbfread/dbf.py
@@ -311,6 +311,14 @@ class DBF(object):
                 else:
                     skip_record(infile)
 
+    def to_dataframe(self):
+        """Convert records to a pandas.DataFrame"""
+        import pandas as pd
+        iterator = self._iter_records(b' ')
+        df = pd.DataFrame(iterator)
+
+        return df
+
     def __iter__(self):
         if self.loaded:
             return list.__iter__(self._records)


### PR DESCRIPTION
With [Pandas](http://pandas.pydata.org/) becoming de facto a standard tool for python data analysis, it can be useful to specify the best way (memory efficient etc) of exporting of DBF records to a `pandas.DataFrame` for latter processing.

This Pull Request adds a `DBF.to_dataframe` method which can be used as follows,

    In [1]: from dbfread import DBF
       ...: db = DBF("/tmp/people.dbf")
       ...: db.to_dataframe()
    Out[1]:
        BIRTHDATE   NAME
    0  1987-03-01  Alice
    1  1980-11-12    Bob

This does not add the `pandas` dependency to `dbfread`: `pandas` is indeed imported in the `to_dataframe` method but presumably people who would be interested in this would have pandas installed, while it should not impact the rest of the users. 

If for design reasons adding this import is an issue, feel free to reject this PR. Although, in this case, adding a small section in the documentation regarding conversion to pandas could be nice. 

This basic code could be later extended to ensure that different fields have the correct type in the DataFrame (e.g. `date` type for the  `BIRTHDATE`). 
