### PR TITLE
Parse char field - Decode with 'errors'

### DIFF
--- a/dbfread/dbf.py
+++ b/dbfread/dbf.py
@@ -82,7 +82,8 @@ class DBF(object):
                  recfactory=collections.OrderedDict,
                  load=False,
                  raw=False,
-                 ignore_missing_memofile=False):
+                 ignore_missing_memofile=False,
+                 char_decode_errors='strict'):
 
         self.encoding = encoding
         self.ignorecase = ignorecase
@@ -90,6 +91,7 @@ class DBF(object):
         self.parserclass = parserclass
         self.raw = raw
         self.ignore_missing_memofile = ignore_missing_memofile
+        self.char_decode_errors = char_decode_errors
 
         if recfactory is None:
             self.recfactory = lambda items: items

--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -34,6 +34,7 @@ class FieldParser:
         self.table = table
         self.dbversion = self.table.header.dbversion
         self.encoding = table.encoding
+        self.char_decode_errors = table.char_decode_errors
         self._lookup = self._create_lookup_table()
         if memofile:
             self.get_memo = memofile.__getitem__
@@ -80,7 +81,7 @@ class FieldParser:
 
     def parseC(self, field, data):
         """Parse char field and return unicode string"""
-        return decode_text(data.rstrip(b'\0 '), self.encoding)
+        return decode_text(data.rstrip(b'\0 '), self.encoding, errors=self.char_decode_errors)
 
     def parseD(self, field, data):
         """Parse date field and return datetime.date or None"""


### PR DESCRIPTION
Thanks for dbfread! It is useful and helps me a lot!

However, I found a problem when I use dbfread. 

When I try to decode a string, it often occurs that the encoding set can not parse some singular characters, and then it raises exception. 

We can use the 'errors' filed to solve this problem. 

>>> a = 'XXX'
>>> a.decode(encoding='YYY', errors='replace')

So I add this filed to dbfread to solve this problem. Use it like: 

>>> DBF('XXX.dbf', encoding='YYY', char_decode_errors='replace')

