### PR TITLE
handle byte literal in parseN

### DIFF
--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -169,6 +169,8 @@ class FieldParser:
         except ValueError:
             if not data.strip():
                 return None
+            elif isinstance(data, (bytes, bytearray)):
+                return int.from_bytes(data, byteorder='big', signed=True)            
             else:
                 # Account for , in numeric fields
                 return float(data.replace(b',', b'.'))


### PR DESCRIPTION
I think this will work when byte literals persist in the data object for this field type. 