### PR TITLE
Considers the number of fields in the headers instead 0x0D headers end

### DIFF
--- a/dbfread/dbf.py
+++ b/dbfread/dbf.py
@@ -224,7 +224,8 @@ class DBF(object):
         return data.decode(self.encoding, errors=self.char_decode_errors)
 
     def _read_field_headers(self, infile):
-        while True:
+        fields = int((self.header.headerlen - DBFField.size - 1)/DBFField.size)
+        for i in range(fields):
             sep = infile.read(1)
             if sep in (b'\r', b'\n', b''):
                 # End of field headers

--- a/dbfread/dbf.py
+++ b/dbfread/dbf.py
@@ -224,7 +224,8 @@ class DBF(object):
         return data.decode(self.encoding, errors=self.char_decode_errors)
 
     def _read_field_headers(self, infile):
-        fields = int((self.header.headerlen - DBFField.size - 1)/DBFField.size)
+        sizeFieldHeader = self.header.headerlen - DBFField.size - 1
+        fields = int(sizeFieldHeader / DBFField.size)
         for i in range(fields):
             sep = infile.read(1)
             if sep in (b'\r', b'\n', b''):


### PR DESCRIPTION
Some .dbf files lack the 0x0D flag at the end of the header, which in turn makes some software misbehave.

The fix implemented just remove the 'while true' in _read_field_headers and considers the number of fields in the headers instead 0x0D headers end