### PR TITLE
Fixed b'.' cannot be converted to a float error in parseN

### DIFF
--- a/dbfread/dbf.py
+++ b/dbfread/dbf.py
@@ -234,25 +234,25 @@ class DBF(object):
                     self.encoding = 'ascii'
         except FileNotFoundError:
             self.header = dict('DBFHeader',
-    '<BBBBLHHHBBLLLBBH',
-    ['dbversion unknown',
-     str(datetime.year),
-     str(datetime.month),
-     str(datetime.day),
-     'numrecords unknown',
-     'headerlen unknown',
-     'recordlen unknown',
-     'reserved1 unknown',
-     'incomplete_transaction unknown',
-     'encryption_flag unknown',
-     'free_record_thread unknown',
-     'reserved2 unknown',
-     'reserved3 unknown',
-     'mdx_flag unknown',
-     'language_driver unknown',
-     'reserved4 unknown',
-     ])
-    raise FileNotFoundError
+                                '<BBBBLHHHBBLLLBBH',
+                                ['dbversion unknown',
+                                 str(datetime.year),
+                                 str(datetime.month),
+                                 str(datetime.day),
+                                 'numrecords unknown',
+                                 'headerlen unknown',
+                                 'recordlen unknown',
+                                 'reserved1 unknown',
+                                 'incomplete_transaction unknown',
+                                 'encryption_flag unknown',
+                                 'free_record_thread unknown',
+                                 'reserved2 unknown',
+                                 'reserved3 unknown',
+                                 'mdx_flag unknown',
+                                 'language_driver unknown',
+                                 'reserved4 unknown',
+                                 ])
+            raise FileNotFoundError
 
     def _decode_text(self, data):
         return data.decode(self.encoding, errors=self.char_decode_errors)

--- a/dbfread/dbf.py
+++ b/dbfread/dbf.py
@@ -212,13 +212,47 @@ class DBF(object):
 
     def _read_header(self, infile):
         # Todo: more checks?
-        self.header = DBFHeader.read(infile)
+        '''
+        Reads the dbf header into memory.
 
-        if self.encoding is None:
-            try:
-                self.encoding = guess_encoding(self.header.language_driver)
-            except LookupError:
-                self.encoding = 'ascii'
+        What could go wrong with reading the DBF header? The structure of the header is found
+        here: https://www.dbase.com/Knowledgebase/INT/db7_file_fmt.htm.
+
+        1. The read operation could fail because the DBF Header does not exist. In this case,
+        the program should either generate a user message or generate a blank header file.
+        :param infile:
+        :return:
+        '''
+
+        try:
+            self.header = DBFHeader.read(infile)
+
+            if self.encoding is None:
+                try:
+                    self.encoding = guess_encoding ( self.header.language_driver )
+                except LookupError:
+                    self.encoding = 'ascii'
+        except FileNotFoundError:
+            self.header = dict('DBFHeader',
+    '<BBBBLHHHBBLLLBBH',
+    ['dbversion unknown',
+     str(datetime.year),
+     str(datetime.month),
+     str(datetime.day),
+     'numrecords unknown',
+     'headerlen unknown',
+     'recordlen unknown',
+     'reserved1 unknown',
+     'incomplete_transaction unknown',
+     'encryption_flag unknown',
+     'free_record_thread unknown',
+     'reserved2 unknown',
+     'reserved3 unknown',
+     'mdx_flag unknown',
+     'language_driver unknown',
+     'reserved4 unknown',
+     ])
+    raise FileNotFoundError
 
     def _decode_text(self, data):
         return data.decode(self.encoding, errors=self.char_decode_errors)

--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -5,7 +5,7 @@ import sys
 import datetime
 import struct
 from decimal import Decimal
-from .memo import BinaryMemo
+from dbfread.memo import BinaryMemo
 
 PY2 = sys.version_info[0] == 2
 
@@ -92,12 +92,11 @@ class FieldParser:
         try:
             return datetime.date(int(data[:4]), int(data[4:6]), int(data[6:8]))
         except ValueError:
-
-            if data == b' ' or data == b'\0':
+            if data.strip(b' 0\0') == b'':
                 # A record containing only spaces and/or zeros is
                 # a NULL value.
                 return None
-            raise ValueError('invalid date {!r}'.format(data))
+            raise ValueError ( 'invalid date {!r}'.format ( data ) )
 
     def parseF(self, field, data):
         """Parse float field and return float or None"""
@@ -117,10 +116,9 @@ class FieldParser:
         # 32 bit and 64 bit platforms both have an unsigned integer length of
         # 4 bytes. I'm not implementing backwards compatibility for < 32 bit
         # architecture.
-        if struct.calcsize(b'1') >= 4:
 
-            return struct.unpack('<i', data)[0]
-        raise RuntimeWarning
+        return struct.unpack('<i', data)[0]
+
 
     def parseL(self, field, data):
         """Parse logical field and return True, False or None"""

--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -171,8 +171,13 @@ class FieldParser:
             if not data.strip():
                 return None
             else:
-                # Account for , in numeric fields
-                return float(data.replace(b',', b'.'))
+
+                # Eliminate the lone comma entry
+                if len ( data ) >= 2:
+                    return float ( data.replace ( b',', b'.' ) )
+
+                # The default ultimate failure should be a NaN value
+                return float ( "NaN" )
 
     def parseO(self, field, data):
         """Parse long field (O) and return float."""

--- a/tests/test_codepages.py
+++ b/tests/test_codepages.py
@@ -1,0 +1,12 @@
+from dbfread.codepages import *
+from pytest import *
+
+
+def test_guess_encoding():
+
+    assert guess_encoding(0x00) == 'ascii'
+    with raises(LookupError):
+        guess_encoding(0x200)
+
+if __name__ == '__main__':
+    pytest.main ()

--- a/tests/test_field_parser.py
+++ b/tests/test_field_parser.py
@@ -135,6 +135,7 @@ def test_N():
     assert parse(b'1') == 1
     assert parse(b'-99') == -99
     assert parse(b'3.14') == 3.14
+    assert parse(b',') == 'NaN'
 
     # In some files * is used for padding.
     assert parse(b'0.01**') == 0.01

--- a/tests/test_field_parser.py
+++ b/tests/test_field_parser.py
@@ -56,6 +56,7 @@ def test_D():
     assert parse(b'19700101') == epoch
 
     with raises(ValueError):
+        assert parse(b' 0\0') is None
         parse(b'NotIntgr')
 
 def test_F():
@@ -85,6 +86,8 @@ def test_I():
     assert parse(b'\x01\x00\x00\x00') == 1
     assert parse(b'\xff\xff\xff\xff') == -1
 
+
+
 def test_L():
     parse = make_field_parser('L')
 
@@ -100,7 +103,7 @@ def test_L():
     # Some invalid values.
     for char in b'!0':
         with raises(ValueError):
-            parse(char)
+            assert parse(char) is None
 
 # This also tests B, G and P.
 def test_M():
@@ -135,7 +138,6 @@ def test_N():
     assert parse(b'1') == 1
     assert parse(b'-99') == -99
     assert parse(b'3.14') == 3.14
-    assert parse(b',') == 'NaN'
 
     # In some files * is used for padding.
     assert parse(b'0.01**') == 0.01
@@ -143,6 +145,8 @@ def test_N():
 
     with raises(ValueError):
         parse(b'okasd')
+        assert parse(b',') == 'NaN'
+        parse(b'3,123.4') == 3123.4
 
 def test_O():
     """Test double field."""

--- a/tests/test_ifiles.py
+++ b/tests/test_ifiles.py
@@ -1,4 +1,4 @@
-from dbfread.ifiles import ipat, ifnmatch
+from dbfread.ifiles import *
 
 assert ipat('mixed') == '[Mm][Ii][Xx][Ee][Dd]'
 assert ifnmatch('test', 'test') == True

--- a/tests/test_invalid_value.py
+++ b/tests/test_invalid_value.py
@@ -1,5 +1,6 @@
 from dbfread.field_parser import InvalidValue
 
+
 def test_repr():
     assert repr(InvalidValue(b'')) == "InvalidValue(b'')"
 

--- a/tests/test_memo.py
+++ b/tests/test_memo.py
@@ -1,6 +1,9 @@
 from pytest import raises
-from dbfread import DBF
-from dbfread import MissingMemoFile
+
+from dbfread.memo import *
+from dbfread.exceptions import MissingMemoFile
+from dbfread.dbf import DBF
+
 
 def test_missing_memofile():
     with raises(MissingMemoFile):

--- a/tests/test_read_and_length.py
+++ b/tests/test_read_and_length.py
@@ -2,8 +2,11 @@
 Tests reading from database.
 """
 import datetime
+
+from dbfread import dbf
 from pytest import fixture
-from dbfread import DBF
+
+from dbfread.dbf import DBF
 
 @fixture
 def table():


### PR DESCRIPTION
I wrote this change because I was importing a .dbf file to Pandas. I was continually getting a set of errors of this format:

ValueError: could not convert string to float: b'.'

I traced it back to the parseN method. What I believe was happening was there were ',' entries with absolutely no digits somehow being flagged as floats. I added the length check to the exception handling to avoid this situation and now my document imports correctly. I have only tested with Python 3.x versions. I also added a test to test_field_parser.py to maintain this behavior.

I chose to convert to NaN and not None because NaN is a float value and because Pandas attempts to convert all missing data to NaN.