### PR TITLE
Add handling for duplicate column names in DBF files

### DIFF
--- a/dbfread/dbf.py
+++ b/dbfread/dbf.py
@@ -224,6 +224,9 @@ class DBF(object):
         return data.decode(self.encoding, errors=self.char_decode_errors)
 
     def _read_field_headers(self, infile):
+        field_names = set()
+        field_counter = {}
+
         while True:
             sep = infile.read(1)
             if sep in (b'\r', b'\n', b''):
@@ -245,8 +248,15 @@ class DBF(object):
             if self.lowernames:
                 field.name = field.name.lower()
 
-            self.field_names.append(field.name)
+            # Check for duplicate field names and append a suffix
+            original_name = field.name
+            if field.name in field_names:
+                field_counter[original_name] = field_counter.get(original_name, 0) + 1
+                field.name = f"{original_name}_{field_counter[original_name]}"
+            else:
+                field_names.add(field.name)
 
+            self.field_names.append(field.name)
             self.fields.append(field)
 
     def _open_memofile(self):

--- a/dbfread/version.py
+++ b/dbfread/version.py
@@ -15,5 +15,5 @@ def _make_version_info(version):
     return VersionInfo(major, minor, micro, releaselevel, 0)
 
 
-version = '2.0.7'
+version = '2.0.8'
 version_info = _make_version_info(version)

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[],
-    python_requires='>=2.7.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
+    python_requires='>=2.7, !=3.0, !=3.1, !=3.2, !=3.3, !=3.4, !=3.5',
     license='MIT',
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -52,5 +52,5 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-    ),
+    ],
 )


### PR DESCRIPTION
This update addresses an issue where dbfread encounters DBF files with duplicate column names, often due to truncated names. Previously, dbfread would load these columns as-is, which could cause problems in subsequent processes, such as converting the data to a pandas DataFrame, which requires unique column names.

My revision enables dbfread to automatically rename duplicate column names by appending a suffix. This change ensures better compatibility with pandas and other data processing tools, preventing potential conflicts or data loss when dealing with DBF files containing columns with identical names.