### PR TITLE
Fix build and test for big-endian

### DIFF
--- a/dbfread/field_parser.py
+++ b/dbfread/field_parser.py
@@ -176,7 +176,7 @@ class FieldParser:
 
     def parseO(self, field, data):
         """Parse long field (O) and return float."""
-        return struct.unpack('d', data)[0]
+        return struct.unpack('<d', data)[0]
 
     def parseT(self, field, data):
         """Parse time field (T)


### PR DESCRIPTION
In dbfread, struct.unpack by default uses the machine local endianess. However, when using a big-endian machine, this leads to failures in the test suite. This change enforces the usage of little-endian in struct.unpack.